### PR TITLE
fix bootstrap on newer clang

### DIFF
--- a/toolsrc/CMakeLists.txt
+++ b/toolsrc/CMakeLists.txt
@@ -58,6 +58,7 @@ if(CLANG AND NOT MSVC)
     if ( NOT USES_LIBSTDCXX AND NOT USES_LIBCXX )
         message(FATAL_ERROR "Can't find which C++ runtime is in use")
     endif()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__cpp_lib_filesystem")
 endif()
 
 if(GCC OR (CLANG AND USES_LIBSTDCXX))

--- a/toolsrc/include/pch.h
+++ b/toolsrc/include/pch.h
@@ -27,7 +27,7 @@
 #include <cstdarg>
 #include <cstddef>
 #include <cstdint>
-#if defined(_WIN32)
+#if (defined(_MSC_VER) && _MSC_VER > 1900) || defined(__cpp_lib_filesystem)
 #include <filesystem>
 #else
 #include <experimental/filesystem>

--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -10,7 +10,7 @@
 
 namespace fs
 {
-#ifdef __cpp_lib_filesystem
+#if defined(_WIN32) || defined(__cpp_lib_filesystem)
     namespace stdfs = std::filesystem;
 #else
     namespace stdfs = std::experimental::filesystem;

--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -10,7 +10,8 @@
 
 namespace fs
 {
-#if defined(_WIN32) || defined(__cpp_lib_filesystem)
+// VS2015 (_MSC_VER 1900) uses std::experimental::filesystem
+#if (defined(_MSC_VER) && _MSC_VER > 1900) || defined(__cpp_lib_filesystem)
     namespace stdfs = std::filesystem;
 #else
     namespace stdfs = std::experimental::filesystem;

--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -2,7 +2,7 @@
 
 #include <vcpkg/base/expected.h>
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__cpp_lib_filesystem)
 #include <filesystem>
 #else
 #include <experimental/filesystem>
@@ -10,7 +10,11 @@
 
 namespace fs
 {
+#ifdef __cpp_lib_filesystem
+    namespace stdfs = std::filesystem;
+#else
     namespace stdfs = std::experimental::filesystem;
+#endif
 
     using stdfs::copy_options;
     using stdfs::file_status;


### PR DESCRIPTION
- Use feature macro to check for support of filesystem
- Use identical check when creating namespace alias
- Update check for VS2015
- Kludge __cpp_lib_filesystem define to fix bootstrapping with newer versions of Apple clang
